### PR TITLE
fix(agent-plugin): Fix nodes_discovery

### DIFF
--- a/agent-plugin/nodes_discovery.pl
+++ b/agent-plugin/nodes_discovery.pl
@@ -19,13 +19,16 @@ foreach my $configFile(@configFiles){
         if(configLineContains($_,"rest-api-interface")){
             chomp;
             my @parts = split(/rest-api-interface/,$_);
-	    my $apiConfig = $parts[1];
-	    @parts = split(/:/,$parts[1]);
-	    my @portParts = split(/\s+/,$parts[1]);
+            my $apiConfig = $parts[1];
+            @parts = split(/:/,$parts[1]);
+            my @portParts = split(/\s+/,$parts[1]);
             my $port = $portParts[0];
             @parts = split(/\s+/,$parts[0]);
             my $host = $parts[$#parts];
             if($host eq "0.0.0.0"){
+                $host = "127.0.0.1";
+            }
+            if($host eq "localhost"){
                 $host = "127.0.0.1";
             }
             $nodeName = $hostName . ":" . $port;


### PR DESCRIPTION
Hello !

First, thanks for this plug-in !

This commit fixes an issue with `nodes-discovery.pl`.

**Issue:**
When the elrond node is configured to expose on `localhost`. The trigger watch if `[{#NODEIP},{#NODEPORT}].sum(#5)}=0` but, with `[{'localhost'},{'8080'}]` the result will always be 0.

So, we modified `nodes-discovery.pl` to return `127.0.0.1` when the exposed host is `localhost`.